### PR TITLE
Small change for C++ 20 compatibility

### DIFF
--- a/immer/transience/gc_transience_policy.hpp
+++ b/immer/transience/gc_transience_policy.hpp
@@ -41,6 +41,7 @@ struct gc_transience_policy
             {
                 void* v;
                 edit() = delete;
+                edit(void *v_) : v(v_) {}
                 bool operator==(edit x) const { return v == x.v; }
                 bool operator!=(edit x) const { return v != x.v; }
             };


### PR DESCRIPTION
In C++ 20, types are no longer considered aggregates if they even _mention_ any constructors (e.g. to explicitly delete one). This means that an instance of the `edit` type modified in this PR can no longer be initialized as:
```c++
edit{nullptr}
```
which was valid in C++ 17.

This PR makes a small change to reinstate the behaviour of the previous implicitly-generated aggregate constructor by hand.