### PR TITLE
C++ 20 equality fix

### DIFF
--- a/immer/detail/iterator_facade.hpp
+++ b/immer/detail/iterator_facade.hpp
@@ -118,6 +118,11 @@ public:
         return derived() + n;
     }
 
+    friend bool operator==(DerivedT const& a, DerivedT const& b)
+    {
+        return access_t::equal(a, b);
+    }
+
     bool operator==(const DerivedT& rhs) const
     {
         return access_t::equal(derived(), rhs);

--- a/immer/detail/iterator_facade.hpp
+++ b/immer/detail/iterator_facade.hpp
@@ -89,7 +89,8 @@ protected:
 
         reference_proxy(DerivedT iter)
             : iter_{std::move(iter)}
-        {}
+        {
+        }
 
     public:
         operator ReferenceT() const { return *iter_; }
@@ -121,10 +122,13 @@ public:
     {
         return access_t::equal(derived(), rhs);
     }
+
+#if __cplusplus < 202002L
     bool operator!=(const DerivedT& rhs) const
     {
         return !access_t::equal(derived(), rhs);
     }
+#endif
 
     DerivedT& operator++()
     {

--- a/immer/detail/iterator_facade.hpp
+++ b/immer/detail/iterator_facade.hpp
@@ -123,17 +123,10 @@ public:
         return access_t::equal(a, b);
     }
 
-    bool operator==(const DerivedT& rhs) const
+    friend bool operator!=(DerivedT const& a, DerivedT const& b)
     {
-        return access_t::equal(derived(), rhs);
+        return !access_t::equal(a, b);
     }
-
-#if __cplusplus < 202002L
-    bool operator!=(const DerivedT& rhs) const
-    {
-        return !access_t::equal(derived(), rhs);
-    }
-#endif
 
     DerivedT& operator++()
     {


### PR DESCRIPTION
In C++ 20, there's a subtle issue where the equality operator can be rewritten to reverse its arguments (that is, for `A::operator==(B const&) const`, the compiler will also look up `B::operator==(A const&) const`). With the way immer uses CRTP to implement an iterator facade, this means that the existing equality operators here are ambiguous.[^1]

The fix is fortunately pretty simple; we can just [downstream](https://github.com/arximboldi/immer/blob/fe0b6f816d6064f263462938b6ed988e4448248b/immer/detail/iterator_facade.hpp#L107-L114) the implementation from the main immer repository into our version.

[^1]: The reason is that, simplifying the types somewhat, `facade<T>::operator==(T)` ends up resolving to two equally-good choices: `operator==(facade<T>, T)` and `operator==(T, facade<T>)`.