### PR TITLE
Revert "Add actual constructor to edit"

### DIFF
--- a/immer/transience/gc_transience_policy.hpp
+++ b/immer/transience/gc_transience_policy.hpp
@@ -44,7 +44,6 @@ struct gc_transience_policy
                     : v{v_}
                 {}
                 edit() = delete;
-                edit(void *v_) : v(v_) {}
                 bool operator==(edit x) const { return v == x.v; }
                 bool operator!=(edit x) const { return v != x.v; }
             };


### PR DESCRIPTION
This PR backs out a change I made manually; because of formatting differences this got stacked on top of the equivalent change in the immer history rather than being merged together.

This reverts commit f4ec7e2c535ddd5667e67021f77fa9e841256567.